### PR TITLE
zbc.py -> zbc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ then `cd` to the package directory and run::
 If the installation finishes without errors you should be able to start the GUI
 from the command line by typing::
 
-    $ zbc.py
+    $ zbc
 
 Changelog
 =========


### PR DESCRIPTION
"zbc.py" was not recognized as an internal or external command to start the program, however, just "zbc" does work.